### PR TITLE
feat: 인가 로직 구현

### DIFF
--- a/src/main/java/com/dowe/auth/application/AuthService.java
+++ b/src/main/java/com/dowe/auth/application/AuthService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dowe.auth.dto.LoginData;
+import com.dowe.auth.dto.TokenPair;
 import com.dowe.member.Member;
 import com.dowe.member.Provider;
 import com.dowe.member.application.MemberService;
@@ -32,6 +33,10 @@ public class AuthService {
 				Member member = memberService.register(provider, authId);
 				return LoginData.from(member, tokenManager.issue(member.getId()), true);
 			});
+	}
+
+	public TokenPair refresh(String refreshToken) {
+		return tokenManager.refresh(refreshToken);
 	}
 
 }

--- a/src/main/java/com/dowe/auth/application/TokenManager.java
+++ b/src/main/java/com/dowe/auth/application/TokenManager.java
@@ -1,5 +1,6 @@
 package com.dowe.auth.application;
 
+import static com.dowe.exception.auth.TokenType.*;
 import static com.dowe.util.AppConstants.*;
 
 import java.util.Date;
@@ -11,12 +12,17 @@ import com.dowe.auth.dto.TokenPair;
 import com.dowe.auth.infrastructure.MemberTokenRepository;
 import com.dowe.config.properties.JwtProperties;
 import com.dowe.exception.auth.ExpiredTokenException;
+import com.dowe.exception.auth.InvalidTokenException;
+import com.dowe.exception.auth.TokenType;
 
+import io.jsonwebtoken.ClaimJwtException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Header;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SignatureException;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -31,8 +37,8 @@ public class TokenManager {
 		Date accessTokenExpiredAt = new Date(now.getTime() + jwtProperties.getAccessTokenExpiry());
 		Date refreshTokenExpiredAt = new Date(now.getTime() + jwtProperties.getRefreshTokenExpiry());
 
-		String accessToken = generateJwt(now, accessTokenExpiredAt, memberId);
-		String refreshToken = generateJwt(now, refreshTokenExpiredAt, memberId);
+		String accessToken = generateJwt(now, accessTokenExpiredAt, memberId, ACCESS_TOKEN);
+		String refreshToken = generateJwt(now, refreshTokenExpiredAt, memberId, REFRESH_TOKEN);
 
 		MemberToken memberToken = MemberToken.builder()
 			.memberId(memberId)
@@ -43,27 +49,52 @@ public class TokenManager {
 		return new TokenPair(accessToken, refreshToken);
 	}
 
-	public Long parse(String token) {
+	public Long parse(String token, TokenType type) {
 		try {
 			Claims claims = Jwts.parser()
 				.setSigningKey(jwtProperties.getSecretKey())
 				.parseClaimsJws(token)
 				.getBody();
+
+			if (getTokenTypeFromClaims(claims, TOKEN_TYPE) != type) {
+				throw new InvalidTokenException(type);
+			}
+
 			return claims.get(MEMBER_ID, Long.class);
 		} catch (ExpiredJwtException e) {
-			throw new ExpiredTokenException();
+			throw new ExpiredTokenException(type);
+		} catch (MalformedJwtException | SignatureException | ClaimJwtException e) {
+			throw new InvalidTokenException(type);
 		}
 	}
 
-	private String generateJwt(Date now, Date expiredAt, Long memberId) {
+	public TokenPair refresh(String refreshToken) {
+		Long memberId = parse(refreshToken, REFRESH_TOKEN);
+		MemberToken memberToken = memberTokenRepository.findById(memberId)
+			.orElseThrow(() -> new InvalidTokenException(REFRESH_TOKEN));
+
+		if (!memberToken.getRefreshToken().equals(refreshToken)) {
+			throw new InvalidTokenException(REFRESH_TOKEN);
+		}
+
+		return issue(memberId);
+	}
+
+	private String generateJwt(Date now, Date expiredAt, Long memberId, TokenType type) {
 		return Jwts.builder()
 			.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
 			.setIssuer(jwtProperties.getIssuer())
 			.setIssuedAt(now)
 			.setExpiration(expiredAt)
 			.claim(MEMBER_ID, memberId)
+			.claim(TOKEN_TYPE, type)
 			.signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
 			.compact();
+	}
+
+	private TokenType getTokenTypeFromClaims(Claims claims, String key) {
+		String type = claims.get(key, String.class);
+		return TokenType.valueOf(type);
 	}
 
 }

--- a/src/main/java/com/dowe/auth/presentation/AuthController.java
+++ b/src/main/java/com/dowe/auth/presentation/AuthController.java
@@ -1,13 +1,18 @@
 package com.dowe.auth.presentation;
 
+import static com.dowe.util.AppConstants.*;
+import static org.springframework.http.HttpHeaders.*;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dowe.auth.application.AuthService;
 import com.dowe.auth.dto.LoginData;
+import com.dowe.auth.dto.TokenPair;
 import com.dowe.member.Provider;
 import com.dowe.util.api.ApiResponse;
 import com.dowe.util.api.ResponseResult;
@@ -24,6 +29,14 @@ public class AuthController {
 	public ResponseEntity<ApiResponse<LoginData>> login(@PathVariable Provider provider, @RequestParam String authorizationCode) {
 		return ResponseEntity.ok()
 			.body(ApiResponse.ok(ResponseResult.LOGIN_SUCCESS, authService.login(provider, authorizationCode)));
+	}
+
+	@GetMapping("/oauth/refresh")
+	public ResponseEntity<ApiResponse<TokenPair>> refreshToken(@RequestHeader(AUTHORIZATION) String header) {
+		String refreshToken = header.substring(BEARER.length());
+
+		return ResponseEntity.ok()
+			.body(ApiResponse.ok(ResponseResult.TOKEN_REFRESH_SUCCESS, authService.refresh(refreshToken)));
 	}
 
 }

--- a/src/main/java/com/dowe/config/WebConfig.java
+++ b/src/main/java/com/dowe/config/WebConfig.java
@@ -2,14 +2,42 @@ package com.dowe.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.dowe.config.converter.ProviderConverter;
+import com.dowe.util.interceptor.LoginInterceptor;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+	private final LoginInterceptor loginInterceptor;
+
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**")
+			.allowedOrigins("http://localhost:3000")
+			.allowedMethods("*")
+			.allowCredentials(true)
+			.exposedHeaders(HttpHeaders.AUTHORIZATION)
+			.maxAge(3000);
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(loginInterceptor)
+			.addPathPatterns("/**")
+			.excludePathPatterns("/docs/index.html", "/oauth/**")
+			.order(Ordered.HIGHEST_PRECEDENCE);
+	}
 
 	@Override
 	public void addFormatters(FormatterRegistry registry) {

--- a/src/main/java/com/dowe/exception/ErrorType.java
+++ b/src/main/java/com/dowe/exception/ErrorType.java
@@ -10,7 +10,8 @@ public enum ErrorType {
 	// Auth
 	INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 OAuth Provider입니다"),
 	INVALID_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST, "잘못된 인증 코드입니다"),
-	EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다");
+	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 토큰입니다"),
+	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/dowe/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dowe/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.dowe.auth.application.AuthService;
+import com.dowe.exception.auth.TokenException;
 import com.dowe.exception.member.MemberRegisterException;
 import com.dowe.util.api.ApiResponse;
 import com.dowe.util.api.ResponseResult;
@@ -59,6 +60,17 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ApiResponse<Object>> handleMemberRegisterException(MemberRegisterException exception) {
 		return ResponseEntity.ok()
 			.body(ApiResponse.ok(ResponseResult.LOGIN_SUCCESS, authService.generateLoginData(exception.getProvider(), exception.getAuthId())));
+	}
+
+	@ExceptionHandler(TokenException.class)
+	public ResponseEntity<ApiResponse<Object>> handleTokenException(TokenException exception) {
+		Map<String, String> error = new LinkedHashMap<>(2);
+		error.put("type", exception.getClass().getSimpleName());
+		error.put("message", exception.getMessage());
+		error.put("needTokenType", exception.getNeedTokenType().name());
+
+		return ResponseEntity.status(exception.getStatus())
+			.body(ApiResponse.of(exception.getStatus(), ResponseResult.EXCEPTION_OCCURRED, List.of(error)));
 	}
 
 }

--- a/src/main/java/com/dowe/exception/auth/ExpiredTokenException.java
+++ b/src/main/java/com/dowe/exception/auth/ExpiredTokenException.java
@@ -1,12 +1,11 @@
 package com.dowe.exception.auth;
 
-import com.dowe.exception.CustomException;
 import com.dowe.exception.ErrorType;
 
-public class ExpiredTokenException extends CustomException {
+public class ExpiredTokenException extends TokenException {
 
-	public ExpiredTokenException() {
-		super(ErrorType.EXPIRED_TOKEN);
+	public ExpiredTokenException(TokenType type) {
+		super(ErrorType.EXPIRED_TOKEN, type);
 	}
 
 }

--- a/src/main/java/com/dowe/exception/auth/InvalidTokenException.java
+++ b/src/main/java/com/dowe/exception/auth/InvalidTokenException.java
@@ -1,0 +1,11 @@
+package com.dowe.exception.auth;
+
+import com.dowe.exception.ErrorType;
+
+public class InvalidTokenException extends TokenException {
+
+	public InvalidTokenException(TokenType type) {
+		super(ErrorType.INVALID_TOKEN, type);
+	}
+
+}

--- a/src/main/java/com/dowe/exception/auth/TokenException.java
+++ b/src/main/java/com/dowe/exception/auth/TokenException.java
@@ -1,0 +1,18 @@
+package com.dowe.exception.auth;
+
+import com.dowe.exception.CustomException;
+import com.dowe.exception.ErrorType;
+
+import lombok.Getter;
+
+@Getter
+public class TokenException extends CustomException {
+
+	private final TokenType needTokenType;
+
+	public TokenException(ErrorType errorType, TokenType type) {
+		super(errorType);
+		this.needTokenType = type;
+	}
+
+}

--- a/src/main/java/com/dowe/exception/auth/TokenType.java
+++ b/src/main/java/com/dowe/exception/auth/TokenType.java
@@ -1,0 +1,7 @@
+package com.dowe.exception.auth;
+
+public enum TokenType {
+
+	ACCESS_TOKEN, REFRESH_TOKEN
+
+}

--- a/src/main/java/com/dowe/member/application/MemberService.java
+++ b/src/main/java/com/dowe/member/application/MemberService.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.dowe.exception.member.MemberRegisterException;
 import com.dowe.member.Member;
@@ -15,6 +16,7 @@ import com.dowe.member.infrastructure.MemberRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MemberService {
 
@@ -25,6 +27,7 @@ public class MemberService {
 		return memberRepository.findByProvider(provider, authId);
 	}
 
+	@Transactional
 	public Member register(Provider provider, String authId) {
 		Member member = Member.builder()
 			.provider(provider)

--- a/src/main/java/com/dowe/util/AppConstants.java
+++ b/src/main/java/com/dowe/util/AppConstants.java
@@ -11,5 +11,6 @@ public final class AppConstants {
 	public static final String BEARER = "Bearer ";
 	public static final String X_WWW_FORM_URLENCODED_CHARSET_UTF_8 = "application/x-www-form-urlencoded;charset=utf-8";
 	public static final String MEMBER_CODE_SET = "memberCode";
+	public static final String TOKEN_TYPE = "tokenType";
 
 }

--- a/src/main/java/com/dowe/util/api/ResponseResult.java
+++ b/src/main/java/com/dowe/util/api/ResponseResult.java
@@ -7,6 +7,7 @@ public enum ResponseResult {
 
 	// Auth
 	LOGIN_SUCCESS("로그인을 성공했습니다"),
+	TOKEN_REFRESH_SUCCESS("토큰 업데이트에 성공했습니다"),
 
 	// Common
 	EXCEPTION_OCCURRED("예외가 발생했습니다");

--- a/src/main/java/com/dowe/util/interceptor/LoginInterceptor.java
+++ b/src/main/java/com/dowe/util/interceptor/LoginInterceptor.java
@@ -1,0 +1,42 @@
+package com.dowe.util.interceptor;
+
+import static com.dowe.exception.auth.TokenType.*;
+import static com.dowe.util.AppConstants.*;
+import static org.springframework.http.HttpHeaders.*;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.dowe.auth.application.TokenManager;
+import com.dowe.exception.auth.InvalidTokenException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class LoginInterceptor implements HandlerInterceptor {
+
+	private final TokenManager tokenManager;
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+		if (CorsUtils.isPreFlightRequest(request)) {
+			return true;
+		}
+		String header = request.getHeader(AUTHORIZATION);
+		if (header == null) {
+			throw new InvalidTokenException(ACCESS_TOKEN);
+		}
+		String accessToken = header.substring(BEARER.length());
+		Long memberId = tokenManager.parse(accessToken, ACCESS_TOKEN);
+		log.info("--MEMBER ID {} 로그인 인터셉터 통과", memberId);
+		request.setAttribute(MEMBER_ID, memberId);
+		return true;
+	}
+
+}

--- a/src/main/java/com/dowe/util/resolver/Login.java
+++ b/src/main/java/com/dowe/util/resolver/Login.java
@@ -1,0 +1,11 @@
+package com.dowe.util.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+}

--- a/src/main/java/com/dowe/util/resolver/LoginArgumentResolver.java
+++ b/src/main/java/com/dowe/util/resolver/LoginArgumentResolver.java
@@ -1,0 +1,33 @@
+package com.dowe.util.resolver;
+
+import static com.dowe.util.AppConstants.*;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Login.class);
+		boolean hasLongType = Long.class.isAssignableFrom(parameter.getParameterType());
+
+		return hasLoginAnnotation && hasLongType;
+	}
+
+	@Override
+	public Long resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+		WebDataBinderFactory binderFactory) throws Exception {
+		HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+
+		assert request != null;
+		return (Long)request.getAttribute(MEMBER_ID);
+	}
+}

--- a/src/test/java/com/dowe/RestDocsSupport.java
+++ b/src/test/java/com/dowe/RestDocsSupport.java
@@ -8,6 +8,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.dowe.auth.application.AuthService;
 import com.dowe.auth.presentation.AuthController;
+import com.dowe.util.interceptor.LoginInterceptor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(controllers = {
@@ -24,5 +25,8 @@ public abstract class RestDocsSupport {
 
 	@MockBean
 	protected AuthService authService;
+
+	@MockBean
+	protected LoginInterceptor loginInterceptor;
 
 }

--- a/src/test/java/com/dowe/auth/application/TokenManagerTest.java
+++ b/src/test/java/com/dowe/auth/application/TokenManagerTest.java
@@ -1,5 +1,6 @@
 package com.dowe.auth.application;
 
+import static com.dowe.exception.auth.TokenType.*;
 import static com.dowe.util.AppConstants.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -47,8 +48,8 @@ class TokenManagerTest extends IntegrationTestSupport {
 		TokenPair tokenPair = tokenManager.issue(memberId);
 
 		// then
-		Long memberIdInAccessToken = tokenManager.parse(tokenPair.getAccessToken());
-		Long memberIdInRefreshToken = tokenManager.parse(tokenPair.getRefreshToken());
+		Long memberIdInAccessToken = tokenManager.parse(tokenPair.getAccessToken(), ACCESS_TOKEN);
+		Long memberIdInRefreshToken = tokenManager.parse(tokenPair.getRefreshToken(), REFRESH_TOKEN);
 
 		assertThat(memberId).isEqualTo(memberIdInAccessToken);
 		assertThat(memberId).isEqualTo(memberIdInRefreshToken);
@@ -102,11 +103,12 @@ class TokenManagerTest extends IntegrationTestSupport {
 			.setIssuedAt(now)
 			.setExpiration(now)
 			.claim(MEMBER_ID, 1L)
+			.claim(TOKEN_TYPE, ACCESS_TOKEN)
 			.signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
 			.compact();
 
 		// when // then
-		assertThatThrownBy(() -> tokenManager.parse(expiredToken))
+		assertThatThrownBy(() -> tokenManager.parse(expiredToken, ACCESS_TOKEN))
 			.isInstanceOf(ExpiredTokenException.class);
 	}
 


### PR DESCRIPTION
- token은 TokenException을 상속한 예외를 발생시킴
  - TokenException은 에러 메시지와 필요한 토큰 타입을 생성자로 받음
  - 이로써 accessToken 예외와 refreshToken 예외를 구별가능
  - refreshToken 예외를 받는 경우, 프론트엔드측은 로그인을 해야함
  - TokenException을 받는 ExceptionHandler 추가
  
- 로그인 인터셉터에서 accessToken 검증
  - 만약 유효하지 않은 accessToken이라면 예외 발생
  
- token refresh API 구현
  - refreshToken을 헤더에 담아 요청
  - refreshToken이 정상적이라면 refresh
  - 비정상적이라면 refreshToken 예외 발생
  
- LoginArgumentResolver 작성
- 테스트코드는 아직 안짬