### PR TITLE
test: 인가 관련 일부 테스트 코드 작성 완료

### DIFF
--- a/src/docs/asciidoc/api/auth.adoc
+++ b/src/docs/asciidoc/api/auth.adoc
@@ -61,3 +61,17 @@ include::{snippets}/login-fail-invalid-authorization-code/response-fields.adoc[]
 
 {nbsp}
 
+[[re]]
+=== 토큰 리프레싱 실패 : 유효하지 않은 인증 헤더
+(Authorization 헤더가 없거나 Beaer로 시작하지 않는 경우)
+
+==== HTTP Request
+
+include::{snippets}/refresh-fail-invalid-authorization-header/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/refresh-fail-invalid-authorization-header/http-response.adoc[]
+include::{snippets}/refresh-fail-invalid-authorization-header/response-fields.adoc[]
+
+{nbsp}

--- a/src/main/java/com/dowe/auth/presentation/AuthController.java
+++ b/src/main/java/com/dowe/auth/presentation/AuthController.java
@@ -31,7 +31,7 @@ public class AuthController {
 			.body(ApiResponse.ok(ResponseResult.LOGIN_SUCCESS, authService.login(provider, authorizationCode)));
 	}
 
-	@GetMapping("/oauth/refresh")
+	@GetMapping("/refresh")
 	public ResponseEntity<ApiResponse<TokenPair>> refreshToken(@RequestHeader(AUTHORIZATION) String header) {
 		String refreshToken = header.substring(BEARER.length());
 

--- a/src/main/java/com/dowe/config/WebConfig.java
+++ b/src/main/java/com/dowe/config/WebConfig.java
@@ -37,12 +37,12 @@ public class WebConfig implements WebMvcConfigurer {
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(authorizationHeaderInterceptor)
 			.addPathPatterns("/**")
-			.excludePathPatterns("/docs/index.html", "/oauth/google", "/oauth/kakao", "/error")
+			.excludePathPatterns("/docs/index.html", "/oauth/**", "/error")
 			.order(Ordered.HIGHEST_PRECEDENCE);
 
 		registry.addInterceptor(accessTokenInterceptor)
 			.addPathPatterns("/**")
-			.excludePathPatterns("/docs/index.html", "/oauth/**")
+			.excludePathPatterns("/docs/index.html", "/oauth/**", "/refresh", "/error")
 			.order(Ordered.LOWEST_PRECEDENCE);
 	}
 

--- a/src/test/java/com/dowe/auth/application/TokenManagerTest.java
+++ b/src/test/java/com/dowe/auth/application/TokenManagerTest.java
@@ -114,8 +114,33 @@ class TokenManagerTest extends IntegrationTestSupport {
 	}
 
 	@Test
+	@DisplayName("토큰 타입이 일치하면 정상적으로 memberId를 반환한다")
+	void parseMatchedTokenType() {
+		// given
+		Date issuedAt = new Date();
+		Date expiration = new Date(issuedAt.getTime() + 5000);
+		Long memberId = 1L;
+
+		String accessToken = Jwts.builder()
+			.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+			.setIssuer(jwtProperties.getIssuer())
+			.setIssuedAt(issuedAt)
+			.setExpiration(expiration)
+			.claim(MEMBER_ID, memberId)
+			.claim(TOKEN_TYPE, ACCESS)
+			.signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
+			.compact();
+
+		// when
+		Long loginMemberId = tokenManager.parse(accessToken, ACCESS);
+
+		// then
+		assertThat(loginMemberId).isEqualTo(memberId);
+	}
+
+	@Test
 	@DisplayName("토큰 타입이 일치하지 않으면 예외가 발생한다")
-	void parseTokenType() {
+	void parseMismatchedTokenType() {
 		// given
 		Date issuedAt = new Date();
 		Date expiration = new Date(issuedAt.getTime() + 5000);

--- a/src/test/java/com/dowe/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/dowe/auth/presentation/AuthControllerTest.java
@@ -20,6 +20,7 @@ import com.dowe.auth.application.AuthService;
 import com.dowe.auth.dto.LoginData;
 import com.dowe.exception.ErrorType;
 import com.dowe.exception.auth.InvalidAuthorizationCodeException;
+import com.dowe.exception.auth.InvalidAuthorizationHeaderException;
 import com.dowe.exception.auth.InvalidProviderException;
 import com.dowe.member.Provider;
 import com.dowe.util.api.ResponseResult;
@@ -196,6 +197,33 @@ class AuthControllerTest extends RestDocsSupport {
 				pathParameters(
 					parameterWithName("provider").description("OAuth Provider")
 				),
+				responseFields(
+					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
+					fieldWithPath("status").type(JsonFieldType.STRING).description("상태"),
+					fieldWithPath("result").type(JsonFieldType.STRING).description("결과"),
+					fieldWithPath("data").type(JsonFieldType.ARRAY).description("응답 데이터"),
+					fieldWithPath("data[].type").type(JsonFieldType.STRING).description("오류 타입"),
+					fieldWithPath("data[].message").type(JsonFieldType.STRING).description("오류 메시지")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("토큰 리프레싱 실패 : 유효하지 않은 인증 헤더")
+	void refreshFail_invalidAuthorizationHeader() throws Exception {
+		// when / then
+		mockMvc.perform(get("/oauth/refresh"))
+			.andDo(print())
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.code").value(HttpStatus.UNAUTHORIZED.value()))
+			.andExpect(jsonPath("$.status").value(HttpStatus.UNAUTHORIZED.getReasonPhrase()))
+			.andExpect(jsonPath("$.result").value(ResponseResult.EXCEPTION_OCCURRED.getDescription()))
+			.andExpect(jsonPath("$.data").isArray())
+			.andExpect(jsonPath("$.data[0].type").value(InvalidAuthorizationHeaderException.class.getSimpleName()))
+			.andExpect(jsonPath("$.data[0].message").value(ErrorType.INVALID_AUTHORIZATION_HEADER.getMessage()))
+			.andDo(document("refresh-fail-invalid-authorization-header",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
 				responseFields(
 					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
 					fieldWithPath("status").type(JsonFieldType.STRING).description("상태"),

--- a/src/test/java/com/dowe/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/dowe/auth/presentation/AuthControllerTest.java
@@ -212,7 +212,7 @@ class AuthControllerTest extends RestDocsSupport {
 	@DisplayName("토큰 리프레싱 실패 : 유효하지 않은 인증 헤더")
 	void refreshFail_invalidAuthorizationHeader() throws Exception {
 		// when / then
-		mockMvc.perform(get("/oauth/refresh"))
+		mockMvc.perform(get("/refresh"))
 			.andDo(print())
 			.andExpect(status().isUnauthorized())
 			.andExpect(jsonPath("$.code").value(HttpStatus.UNAUTHORIZED.value()))


### PR DESCRIPTION
- TokenManager에 TokenType이 일치하면 정상 동작
- TokenManager에 TokenType이 일치하지 않으면 예외 발생
- AuthController의 `/refresh` 요청 시 Authorization 헤더 없으면 예외 발생 (documentation)