### PR TITLE
test: 토큰 refresh 관련 테스트 구현

### DIFF
--- a/src/docs/asciidoc/api/auth.adoc
+++ b/src/docs/asciidoc/api/auth.adoc
@@ -61,3 +61,17 @@ include::{snippets}/login-fail-invalid-authorization-code/response-fields.adoc[]
 
 {nbsp}
 
+[[re]]
+=== 토큰 리프레싱 실패 : 유효하지 않은 인증 헤더
+(Authorization 헤더가 없거나 Beaer로 시작하지 않는 경우)
+
+==== HTTP Request
+
+include::{snippets}/refresh-fail-invalid-authorization-header/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/refresh-fail-invalid-authorization-header/http-response.adoc[]
+include::{snippets}/refresh-fail-invalid-authorization-header/response-fields.adoc[]
+
+{nbsp}

--- a/src/docs/asciidoc/api/auth.adoc
+++ b/src/docs/asciidoc/api/auth.adoc
@@ -61,3 +61,32 @@ include::{snippets}/login-fail-invalid-authorization-code/response-fields.adoc[]
 
 {nbsp}
 
+[[token-refresh-success]]
+=== 토큰 refresh 성공
+
+==== HTTP Request
+
+include::{snippets}/token-refresh-success/http-request.adoc[]
+include::{snippets}/token-refresh-success/request-headers.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/token-refresh-success/http-response.adoc[]
+include::{snippets}/token-refresh-success/response-fields.adoc[]
+
+{nbsp}
+
+[[token-refresh-success]]
+=== 토큰 refresh 실패 : refreshToken이 아닌 accessToken을 전달
+
+==== HTTP Request
+
+include::{snippets}/token-refresh-fail-hand-over-access-token/http-request.adoc[]
+include::{snippets}/token-refresh-fail-hand-over-access-token/request-headers.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/token-refresh-fail-hand-over-access-token/http-response.adoc[]
+include::{snippets}/token-refresh-fail-hand-over-access-token/response-fields.adoc[]
+
+{nbsp}

--- a/src/main/java/com/dowe/auth/MemberToken.java
+++ b/src/main/java/com/dowe/auth/MemberToken.java
@@ -23,4 +23,12 @@ public class MemberToken {
 		this.refreshToken = refreshToken;
 	}
 
+	public void changeRefreshToken(String refreshToken) {
+		this.refreshToken = refreshToken;
+	}
+
+	public boolean doesNotMatch(String refreshTokenInput) {
+		return !refreshToken.equals(refreshTokenInput);
+	}
+
 }

--- a/src/main/java/com/dowe/auth/TokenType.java
+++ b/src/main/java/com/dowe/auth/TokenType.java
@@ -1,0 +1,16 @@
+package com.dowe.auth;
+
+import lombok.Getter;
+
+@Getter
+public enum TokenType {
+
+	ACCESS("access token"), REFRESH("refresh token"), FAKE("fake token");
+
+	private final String description;
+
+	TokenType(String description) {
+		this.description = description;
+	}
+
+}

--- a/src/main/java/com/dowe/auth/application/AuthService.java
+++ b/src/main/java/com/dowe/auth/application/AuthService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dowe.auth.dto.LoginData;
+import com.dowe.auth.dto.TokenPair;
 import com.dowe.member.Member;
 import com.dowe.member.Provider;
 import com.dowe.member.application.MemberService;
@@ -32,6 +33,10 @@ public class AuthService {
 				Member member = memberService.register(provider, authId);
 				return LoginData.from(member, tokenManager.issue(member.getId()), true);
 			});
+	}
+
+	public TokenPair refresh(String refreshToken) {
+		return tokenManager.refresh(refreshToken);
 	}
 
 }

--- a/src/main/java/com/dowe/auth/application/AuthService.java
+++ b/src/main/java/com/dowe/auth/application/AuthService.java
@@ -1,5 +1,7 @@
 package com.dowe.auth.application;
 
+import static com.dowe.auth.TokenType.*;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,8 +37,9 @@ public class AuthService {
 			});
 	}
 
-	public TokenPair refresh(String refreshToken) {
-		return tokenManager.refresh(refreshToken);
+	public TokenPair refresh(String refreshTokenInput) {
+		Long memberId = tokenManager.parse(refreshTokenInput, REFRESH);
+		return tokenManager.refresh(memberId, refreshTokenInput);
 	}
 
 }

--- a/src/main/java/com/dowe/auth/application/TokenManager.java
+++ b/src/main/java/com/dowe/auth/application/TokenManager.java
@@ -1,5 +1,6 @@
 package com.dowe.auth.application;
 
+import static com.dowe.exception.auth.TokenType.*;
 import static com.dowe.util.AppConstants.*;
 
 import java.util.Date;
@@ -11,12 +12,17 @@ import com.dowe.auth.dto.TokenPair;
 import com.dowe.auth.infrastructure.MemberTokenRepository;
 import com.dowe.config.properties.JwtProperties;
 import com.dowe.exception.auth.ExpiredTokenException;
+import com.dowe.exception.auth.InvalidTokenException;
+import com.dowe.exception.auth.TokenType;
 
+import io.jsonwebtoken.ClaimJwtException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Header;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SignatureException;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -31,8 +37,8 @@ public class TokenManager {
 		Date accessTokenExpiredAt = new Date(now.getTime() + jwtProperties.getAccessTokenExpiry());
 		Date refreshTokenExpiredAt = new Date(now.getTime() + jwtProperties.getRefreshTokenExpiry());
 
-		String accessToken = generateJwt(now, accessTokenExpiredAt, memberId);
-		String refreshToken = generateJwt(now, refreshTokenExpiredAt, memberId);
+		String accessToken = generateJwt(now, accessTokenExpiredAt, memberId, ACCESS_TOKEN);
+		String refreshToken = generateJwt(now, refreshTokenExpiredAt, memberId, REFRESH_TOKEN);
 
 		MemberToken memberToken = MemberToken.builder()
 			.memberId(memberId)
@@ -43,27 +49,52 @@ public class TokenManager {
 		return new TokenPair(accessToken, refreshToken);
 	}
 
-	public Long parse(String token) {
+	public Long parse(String token, TokenType type) {
 		try {
 			Claims claims = Jwts.parser()
 				.setSigningKey(jwtProperties.getSecretKey())
 				.parseClaimsJws(token)
 				.getBody();
+
+			if (getTokenTypeFromClaims(claims, TOKEN_TYPE) != type) {
+				throw new InvalidTokenException(type);
+			}
+
 			return claims.get(MEMBER_ID, Long.class);
 		} catch (ExpiredJwtException e) {
-			throw new ExpiredTokenException();
+			throw new ExpiredTokenException(type);
+		} catch (MalformedJwtException | SignatureException | ClaimJwtException e) {
+			throw new InvalidTokenException(type);
 		}
 	}
 
-	private String generateJwt(Date now, Date expiredAt, Long memberId) {
+	public TokenPair refresh(String refreshToken) {
+		Long memberId = parse(refreshToken, REFRESH_TOKEN);
+		MemberToken memberToken = memberTokenRepository.findById(memberId)
+			.orElseThrow(() -> new InvalidTokenException(REFRESH_TOKEN));
+
+		if (!memberToken.getRefreshToken().equals(refreshToken)) {
+			throw new InvalidTokenException(REFRESH_TOKEN);
+		}
+
+		return issue(memberId);
+	}
+
+	private String generateJwt(Date now, Date expiredAt, Long memberId, TokenType type) {
 		return Jwts.builder()
 			.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
 			.setIssuer(jwtProperties.getIssuer())
 			.setIssuedAt(now)
 			.setExpiration(expiredAt)
 			.claim(MEMBER_ID, memberId)
+			.claim(TOKEN_TYPE, type)
 			.signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
 			.compact();
+	}
+
+	private TokenType getTokenTypeFromClaims(Claims claims, String key) {
+		String type = claims.get(key, String.class);
+		return TokenType.valueOf(type);
 	}
 
 }

--- a/src/main/java/com/dowe/auth/presentation/AuthController.java
+++ b/src/main/java/com/dowe/auth/presentation/AuthController.java
@@ -33,10 +33,10 @@ public class AuthController {
 
 	@GetMapping("/oauth/refresh")
 	public ResponseEntity<ApiResponse<TokenPair>> refreshToken(@RequestHeader(AUTHORIZATION) String header) {
-		String refreshToken = header.substring(BEARER.length());
+		String refreshTokenInput = header.substring(BEARER.length());
 
 		return ResponseEntity.ok()
-			.body(ApiResponse.ok(ResponseResult.TOKEN_REFRESH_SUCCESS, authService.refresh(refreshToken)));
+			.body(ApiResponse.ok(ResponseResult.TOKEN_REFRESH_SUCCESS, authService.refresh(refreshTokenInput)));
 	}
 
 }

--- a/src/main/java/com/dowe/auth/presentation/AuthController.java
+++ b/src/main/java/com/dowe/auth/presentation/AuthController.java
@@ -3,9 +3,11 @@ package com.dowe.auth.presentation;
 import static com.dowe.util.AppConstants.*;
 import static org.springframework.http.HttpHeaders.*;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,13 +27,13 @@ public class AuthController {
 
 	private final AuthService authService;
 
-	@GetMapping("/oauth/{provider}")
+	@PostMapping("/oauth/{provider}")
 	public ResponseEntity<ApiResponse<LoginData>> login(@PathVariable Provider provider, @RequestParam String authorizationCode) {
-		return ResponseEntity.ok()
-			.body(ApiResponse.ok(ResponseResult.LOGIN_SUCCESS, authService.login(provider, authorizationCode)));
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(ApiResponse.created(ResponseResult.LOGIN_SUCCESS, authService.login(provider, authorizationCode)));
 	}
 
-	@GetMapping("/refresh")
+	@PatchMapping("/refresh")
 	public ResponseEntity<ApiResponse<TokenPair>> refreshToken(@RequestHeader(AUTHORIZATION) String header) {
 		String refreshTokenInput = header.substring(BEARER.length());
 

--- a/src/main/java/com/dowe/auth/presentation/AuthController.java
+++ b/src/main/java/com/dowe/auth/presentation/AuthController.java
@@ -31,7 +31,7 @@ public class AuthController {
 			.body(ApiResponse.ok(ResponseResult.LOGIN_SUCCESS, authService.login(provider, authorizationCode)));
 	}
 
-	@GetMapping("/oauth/refresh")
+	@GetMapping("/refresh")
 	public ResponseEntity<ApiResponse<TokenPair>> refreshToken(@RequestHeader(AUTHORIZATION) String header) {
 		String refreshToken = header.substring(BEARER.length());
 

--- a/src/main/java/com/dowe/auth/presentation/AuthController.java
+++ b/src/main/java/com/dowe/auth/presentation/AuthController.java
@@ -1,13 +1,18 @@
 package com.dowe.auth.presentation;
 
+import static com.dowe.util.AppConstants.*;
+import static org.springframework.http.HttpHeaders.*;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dowe.auth.application.AuthService;
 import com.dowe.auth.dto.LoginData;
+import com.dowe.auth.dto.TokenPair;
 import com.dowe.member.Provider;
 import com.dowe.util.api.ApiResponse;
 import com.dowe.util.api.ResponseResult;
@@ -24,6 +29,14 @@ public class AuthController {
 	public ResponseEntity<ApiResponse<LoginData>> login(@PathVariable Provider provider, @RequestParam String authorizationCode) {
 		return ResponseEntity.ok()
 			.body(ApiResponse.ok(ResponseResult.LOGIN_SUCCESS, authService.login(provider, authorizationCode)));
+	}
+
+	@GetMapping("/oauth/refresh")
+	public ResponseEntity<ApiResponse<TokenPair>> refreshToken(@RequestHeader(AUTHORIZATION) String header) {
+		String refreshToken = header.substring(BEARER.length());
+
+		return ResponseEntity.ok()
+			.body(ApiResponse.ok(ResponseResult.TOKEN_REFRESH_SUCCESS, authService.refresh(refreshToken)));
 	}
 
 }

--- a/src/main/java/com/dowe/config/WebConfig.java
+++ b/src/main/java/com/dowe/config/WebConfig.java
@@ -37,12 +37,12 @@ public class WebConfig implements WebMvcConfigurer {
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(authorizationHeaderInterceptor)
 			.addPathPatterns("/**")
-			.excludePathPatterns("/docs/index.html", "/oauth/google", "/oauth/kakao", "/error")
+			.excludePathPatterns("/docs/index.html", "/oauth/**", "/error")
 			.order(Ordered.HIGHEST_PRECEDENCE);
 
 		registry.addInterceptor(accessTokenInterceptor)
 			.addPathPatterns("/**")
-			.excludePathPatterns("/docs/index.html", "/oauth/**")
+			.excludePathPatterns("/docs/index.html", "/oauth/**", "/refresh", "/error")
 			.order(Ordered.LOWEST_PRECEDENCE);
 	}
 

--- a/src/main/java/com/dowe/config/WebConfig.java
+++ b/src/main/java/com/dowe/config/WebConfig.java
@@ -2,14 +2,42 @@ package com.dowe.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.dowe.config.converter.ProviderConverter;
+import com.dowe.util.interceptor.LoginInterceptor;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+	private final LoginInterceptor loginInterceptor;
+
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**")
+			.allowedOrigins("http://localhost:3000")
+			.allowedMethods("*")
+			.allowCredentials(true)
+			.exposedHeaders(HttpHeaders.AUTHORIZATION)
+			.maxAge(3000);
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(loginInterceptor)
+			.addPathPatterns("/**")
+			.excludePathPatterns("/docs/index.html", "/oauth/**")
+			.order(Ordered.HIGHEST_PRECEDENCE);
+	}
 
 	@Override
 	public void addFormatters(FormatterRegistry registry) {

--- a/src/main/java/com/dowe/config/WebConfig.java
+++ b/src/main/java/com/dowe/config/WebConfig.java
@@ -11,7 +11,8 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.dowe.config.converter.ProviderConverter;
-import com.dowe.util.interceptor.LoginInterceptor;
+import com.dowe.util.interceptor.AccessTokenInterceptor;
+import com.dowe.util.interceptor.AuthorizationHeaderInterceptor;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,7 +20,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-	private final LoginInterceptor loginInterceptor;
+	private final AuthorizationHeaderInterceptor authorizationHeaderInterceptor;
+	private final AccessTokenInterceptor accessTokenInterceptor;
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
@@ -33,10 +35,15 @@ public class WebConfig implements WebMvcConfigurer {
 
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
-		registry.addInterceptor(loginInterceptor)
+		registry.addInterceptor(authorizationHeaderInterceptor)
+			.addPathPatterns("/**")
+			.excludePathPatterns("/docs/index.html", "/oauth/google", "/oauth/kakao", "/error")
+			.order(Ordered.HIGHEST_PRECEDENCE);
+
+		registry.addInterceptor(accessTokenInterceptor)
 			.addPathPatterns("/**")
 			.excludePathPatterns("/docs/index.html", "/oauth/**")
-			.order(Ordered.HIGHEST_PRECEDENCE);
+			.order(Ordered.LOWEST_PRECEDENCE);
 	}
 
 	@Override

--- a/src/main/java/com/dowe/exception/ErrorType.java
+++ b/src/main/java/com/dowe/exception/ErrorType.java
@@ -10,7 +10,8 @@ public enum ErrorType {
 	// Auth
 	INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 OAuth Provider입니다"),
 	INVALID_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST, "잘못된 인증 코드입니다"),
-	EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다");
+	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 토큰입니다"),
+	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/dowe/exception/ErrorType.java
+++ b/src/main/java/com/dowe/exception/ErrorType.java
@@ -10,6 +10,7 @@ public enum ErrorType {
 	// Auth
 	INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 OAuth Provider입니다"),
 	INVALID_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST, "잘못된 인증 코드입니다"),
+	INVALID_AUTHORIZATION_HEADER(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증 헤더입니다"),
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 토큰입니다"),
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다");
 

--- a/src/main/java/com/dowe/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dowe/exception/GlobalExceptionHandler.java
@@ -58,8 +58,8 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(MemberRegisterException.class)
 	public ResponseEntity<ApiResponse<Object>> handleMemberRegisterException(MemberRegisterException exception) {
-		return ResponseEntity.ok()
-			.body(ApiResponse.ok(ResponseResult.LOGIN_SUCCESS, authService.generateLoginData(exception.getProvider(), exception.getAuthId())));
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(ApiResponse.created(ResponseResult.LOGIN_SUCCESS, authService.generateLoginData(exception.getProvider(), exception.getAuthId())));
 	}
 
 	@ExceptionHandler(TokenException.class)

--- a/src/main/java/com/dowe/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dowe/exception/GlobalExceptionHandler.java
@@ -64,10 +64,11 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(TokenException.class)
 	public ResponseEntity<ApiResponse<Object>> handleTokenException(TokenException exception) {
-		Map<String, String> error = new LinkedHashMap<>(2);
+		Map<String, String> error = new LinkedHashMap<>(4);
 		error.put("type", exception.getClass().getSimpleName());
 		error.put("message", exception.getMessage());
-		error.put("needTokenType", exception.getNeedTokenType().name());
+		error.put("currentTokenType", exception.getCurrentTokenType().getDescription());
+		error.put("needTokenType", exception.getNeedTokenType().getDescription());
 
 		return ResponseEntity.status(exception.getStatus())
 			.body(ApiResponse.of(exception.getStatus(), ResponseResult.EXCEPTION_OCCURRED, List.of(error)));

--- a/src/main/java/com/dowe/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dowe/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.dowe.auth.application.AuthService;
+import com.dowe.exception.auth.TokenException;
 import com.dowe.exception.member.MemberRegisterException;
 import com.dowe.util.api.ApiResponse;
 import com.dowe.util.api.ResponseResult;
@@ -59,6 +60,17 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ApiResponse<Object>> handleMemberRegisterException(MemberRegisterException exception) {
 		return ResponseEntity.ok()
 			.body(ApiResponse.ok(ResponseResult.LOGIN_SUCCESS, authService.generateLoginData(exception.getProvider(), exception.getAuthId())));
+	}
+
+	@ExceptionHandler(TokenException.class)
+	public ResponseEntity<ApiResponse<Object>> handleTokenException(TokenException exception) {
+		Map<String, String> error = new LinkedHashMap<>(2);
+		error.put("type", exception.getClass().getSimpleName());
+		error.put("message", exception.getMessage());
+		error.put("needTokenType", exception.getNeedTokenType().name());
+
+		return ResponseEntity.status(exception.getStatus())
+			.body(ApiResponse.of(exception.getStatus(), ResponseResult.EXCEPTION_OCCURRED, List.of(error)));
 	}
 
 }

--- a/src/main/java/com/dowe/exception/auth/ExpiredTokenException.java
+++ b/src/main/java/com/dowe/exception/auth/ExpiredTokenException.java
@@ -1,12 +1,11 @@
 package com.dowe.exception.auth;
 
-import com.dowe.exception.CustomException;
 import com.dowe.exception.ErrorType;
 
-public class ExpiredTokenException extends CustomException {
+public class ExpiredTokenException extends TokenException {
 
-	public ExpiredTokenException() {
-		super(ErrorType.EXPIRED_TOKEN);
+	public ExpiredTokenException(TokenType type) {
+		super(ErrorType.EXPIRED_TOKEN, type);
 	}
 
 }

--- a/src/main/java/com/dowe/exception/auth/ExpiredTokenException.java
+++ b/src/main/java/com/dowe/exception/auth/ExpiredTokenException.java
@@ -1,11 +1,12 @@
 package com.dowe.exception.auth;
 
+import com.dowe.auth.TokenType;
 import com.dowe.exception.ErrorType;
 
 public class ExpiredTokenException extends TokenException {
 
-	public ExpiredTokenException(TokenType type) {
-		super(ErrorType.EXPIRED_TOKEN, type);
+	public ExpiredTokenException(TokenType currentTokenType, TokenType needTokenType) {
+		super(ErrorType.EXPIRED_TOKEN, currentTokenType, needTokenType);
 	}
 
 }

--- a/src/main/java/com/dowe/exception/auth/InvalidAuthorizationHeaderException.java
+++ b/src/main/java/com/dowe/exception/auth/InvalidAuthorizationHeaderException.java
@@ -1,0 +1,12 @@
+package com.dowe.exception.auth;
+
+import com.dowe.exception.CustomException;
+import com.dowe.exception.ErrorType;
+
+public class InvalidAuthorizationHeaderException extends CustomException {
+
+	public InvalidAuthorizationHeaderException() {
+		super(ErrorType.INVALID_AUTHORIZATION_HEADER);
+	}
+
+}

--- a/src/main/java/com/dowe/exception/auth/InvalidTokenException.java
+++ b/src/main/java/com/dowe/exception/auth/InvalidTokenException.java
@@ -1,0 +1,11 @@
+package com.dowe.exception.auth;
+
+import com.dowe.exception.ErrorType;
+
+public class InvalidTokenException extends TokenException {
+
+	public InvalidTokenException(TokenType type) {
+		super(ErrorType.INVALID_TOKEN, type);
+	}
+
+}

--- a/src/main/java/com/dowe/exception/auth/InvalidTokenException.java
+++ b/src/main/java/com/dowe/exception/auth/InvalidTokenException.java
@@ -1,11 +1,12 @@
 package com.dowe.exception.auth;
 
+import com.dowe.auth.TokenType;
 import com.dowe.exception.ErrorType;
 
 public class InvalidTokenException extends TokenException {
 
-	public InvalidTokenException(TokenType type) {
-		super(ErrorType.INVALID_TOKEN, type);
+	public InvalidTokenException(TokenType currentTokenType, TokenType needTokenType) {
+		super(ErrorType.INVALID_TOKEN, currentTokenType, needTokenType);
 	}
 
 }

--- a/src/main/java/com/dowe/exception/auth/TokenException.java
+++ b/src/main/java/com/dowe/exception/auth/TokenException.java
@@ -1,0 +1,18 @@
+package com.dowe.exception.auth;
+
+import com.dowe.exception.CustomException;
+import com.dowe.exception.ErrorType;
+
+import lombok.Getter;
+
+@Getter
+public class TokenException extends CustomException {
+
+	private final TokenType needTokenType;
+
+	public TokenException(ErrorType errorType, TokenType type) {
+		super(errorType);
+		this.needTokenType = type;
+	}
+
+}

--- a/src/main/java/com/dowe/exception/auth/TokenException.java
+++ b/src/main/java/com/dowe/exception/auth/TokenException.java
@@ -1,5 +1,6 @@
 package com.dowe.exception.auth;
 
+import com.dowe.auth.TokenType;
 import com.dowe.exception.CustomException;
 import com.dowe.exception.ErrorType;
 
@@ -8,11 +9,13 @@ import lombok.Getter;
 @Getter
 public class TokenException extends CustomException {
 
+	private final TokenType currentTokenType;
 	private final TokenType needTokenType;
 
-	public TokenException(ErrorType errorType, TokenType type) {
+	public TokenException(ErrorType errorType, TokenType currentTokenType, TokenType needTokenType) {
 		super(errorType);
-		this.needTokenType = type;
+		this.currentTokenType = currentTokenType;
+		this.needTokenType = needTokenType;
 	}
 
 }

--- a/src/main/java/com/dowe/exception/auth/TokenType.java
+++ b/src/main/java/com/dowe/exception/auth/TokenType.java
@@ -1,7 +1,0 @@
-package com.dowe.exception.auth;
-
-public enum TokenType {
-
-	ACCESS_TOKEN, REFRESH_TOKEN
-
-}

--- a/src/main/java/com/dowe/exception/auth/TokenType.java
+++ b/src/main/java/com/dowe/exception/auth/TokenType.java
@@ -1,0 +1,7 @@
+package com.dowe.exception.auth;
+
+public enum TokenType {
+
+	ACCESS_TOKEN, REFRESH_TOKEN
+
+}

--- a/src/main/java/com/dowe/member/application/MemberService.java
+++ b/src/main/java/com/dowe/member/application/MemberService.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.dowe.exception.member.MemberRegisterException;
 import com.dowe.member.Member;
@@ -15,6 +16,7 @@ import com.dowe.member.infrastructure.MemberRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MemberService {
 
@@ -25,6 +27,7 @@ public class MemberService {
 		return memberRepository.findByProvider(provider, authId);
 	}
 
+	@Transactional
 	public Member register(Provider provider, String authId) {
 		Member member = Member.builder()
 			.provider(provider)

--- a/src/main/java/com/dowe/util/AppConstants.java
+++ b/src/main/java/com/dowe/util/AppConstants.java
@@ -11,5 +11,6 @@ public final class AppConstants {
 	public static final String BEARER = "Bearer ";
 	public static final String X_WWW_FORM_URLENCODED_CHARSET_UTF_8 = "application/x-www-form-urlencoded;charset=utf-8";
 	public static final String MEMBER_CODE_SET = "memberCode";
+	public static final String TOKEN_TYPE = "tokenType";
 
 }

--- a/src/main/java/com/dowe/util/api/ResponseResult.java
+++ b/src/main/java/com/dowe/util/api/ResponseResult.java
@@ -7,6 +7,7 @@ public enum ResponseResult {
 
 	// Auth
 	LOGIN_SUCCESS("로그인을 성공했습니다"),
+	TOKEN_REFRESH_SUCCESS("토큰 업데이트에 성공했습니다"),
 
 	// Common
 	EXCEPTION_OCCURRED("예외가 발생했습니다");

--- a/src/main/java/com/dowe/util/interceptor/AccessTokenInterceptor.java
+++ b/src/main/java/com/dowe/util/interceptor/AccessTokenInterceptor.java
@@ -1,6 +1,6 @@
 package com.dowe.util.interceptor;
 
-import static com.dowe.exception.auth.TokenType.*;
+import static com.dowe.auth.TokenType.*;
 import static com.dowe.util.AppConstants.*;
 import static org.springframework.http.HttpHeaders.*;
 
@@ -9,7 +9,6 @@ import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import com.dowe.auth.application.TokenManager;
-import com.dowe.exception.auth.InvalidTokenException;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -17,9 +16,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Component
-@Slf4j
 @RequiredArgsConstructor
-public class LoginInterceptor implements HandlerInterceptor {
+@Slf4j
+public class AccessTokenInterceptor implements HandlerInterceptor {
 
 	private final TokenManager tokenManager;
 
@@ -28,14 +27,13 @@ public class LoginInterceptor implements HandlerInterceptor {
 		if (CorsUtils.isPreFlightRequest(request)) {
 			return true;
 		}
-		String header = request.getHeader(AUTHORIZATION);
-		if (header == null) {
-			throw new InvalidTokenException(ACCESS_TOKEN);
-		}
-		String accessToken = header.substring(BEARER.length());
-		Long memberId = tokenManager.parse(accessToken, ACCESS_TOKEN);
-		log.info("--MEMBER ID {} 로그인 인터셉터 통과", memberId);
+
+		String accessToken = request.getHeader(AUTHORIZATION).substring(BEARER.length());
+		Long memberId = tokenManager.parse(accessToken, ACCESS);
+
+		log.info("-- MEMBER ID {} 엑세스 토큰 인터셉터 통과 --", memberId);
 		request.setAttribute(MEMBER_ID, memberId);
+
 		return true;
 	}
 

--- a/src/main/java/com/dowe/util/interceptor/AuthorizationHeaderInterceptor.java
+++ b/src/main/java/com/dowe/util/interceptor/AuthorizationHeaderInterceptor.java
@@ -1,0 +1,32 @@
+package com.dowe.util.interceptor;
+
+import static com.dowe.util.AppConstants.*;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.dowe.exception.auth.InvalidAuthorizationHeaderException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class AuthorizationHeaderInterceptor implements HandlerInterceptor {
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+		if (CorsUtils.isPreFlightRequest(request)) {
+			return true;
+		}
+
+		String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+		if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER)) {
+			throw new InvalidAuthorizationHeaderException();
+		}
+
+		return true;
+	}
+
+}

--- a/src/main/java/com/dowe/util/interceptor/LoginInterceptor.java
+++ b/src/main/java/com/dowe/util/interceptor/LoginInterceptor.java
@@ -1,0 +1,42 @@
+package com.dowe.util.interceptor;
+
+import static com.dowe.exception.auth.TokenType.*;
+import static com.dowe.util.AppConstants.*;
+import static org.springframework.http.HttpHeaders.*;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.dowe.auth.application.TokenManager;
+import com.dowe.exception.auth.InvalidTokenException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class LoginInterceptor implements HandlerInterceptor {
+
+	private final TokenManager tokenManager;
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+		if (CorsUtils.isPreFlightRequest(request)) {
+			return true;
+		}
+		String header = request.getHeader(AUTHORIZATION);
+		if (header == null) {
+			throw new InvalidTokenException(ACCESS_TOKEN);
+		}
+		String accessToken = header.substring(BEARER.length());
+		Long memberId = tokenManager.parse(accessToken, ACCESS_TOKEN);
+		log.info("--MEMBER ID {} 로그인 인터셉터 통과", memberId);
+		request.setAttribute(MEMBER_ID, memberId);
+		return true;
+	}
+
+}

--- a/src/main/java/com/dowe/util/resolver/Login.java
+++ b/src/main/java/com/dowe/util/resolver/Login.java
@@ -1,0 +1,11 @@
+package com.dowe.util.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+}

--- a/src/main/java/com/dowe/util/resolver/LoginArgumentResolver.java
+++ b/src/main/java/com/dowe/util/resolver/LoginArgumentResolver.java
@@ -1,0 +1,33 @@
+package com.dowe.util.resolver;
+
+import static com.dowe.util.AppConstants.*;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Login.class);
+		boolean hasLongType = Long.class.isAssignableFrom(parameter.getParameterType());
+
+		return hasLoginAnnotation && hasLongType;
+	}
+
+	@Override
+	public Long resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+		WebDataBinderFactory binderFactory) throws Exception {
+		HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+
+		assert request != null;
+		return (Long)request.getAttribute(MEMBER_ID);
+	}
+}

--- a/src/test/java/com/dowe/RestDocsSupport.java
+++ b/src/test/java/com/dowe/RestDocsSupport.java
@@ -8,7 +8,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.dowe.auth.application.AuthService;
 import com.dowe.auth.presentation.AuthController;
-import com.dowe.util.interceptor.LoginInterceptor;
+import com.dowe.util.interceptor.AccessTokenInterceptor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(controllers = {
@@ -27,6 +27,6 @@ public abstract class RestDocsSupport {
 	protected AuthService authService;
 
 	@MockBean
-	protected LoginInterceptor loginInterceptor;
+	protected AccessTokenInterceptor accessTokenInterceptor;
 
 }

--- a/src/test/java/com/dowe/RestDocsSupport.java
+++ b/src/test/java/com/dowe/RestDocsSupport.java
@@ -8,6 +8,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.dowe.auth.application.AuthService;
 import com.dowe.auth.presentation.AuthController;
+import com.dowe.util.interceptor.LoginInterceptor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(controllers = {
@@ -24,5 +25,8 @@ public abstract class RestDocsSupport {
 
 	@MockBean
 	protected AuthService authService;
+
+	@MockBean
+	protected LoginInterceptor loginInterceptor;
 
 }

--- a/src/test/java/com/dowe/RestDocsSupport.java
+++ b/src/test/java/com/dowe/RestDocsSupport.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.dowe.auth.application.AuthService;
@@ -30,7 +31,7 @@ public abstract class RestDocsSupport {
 	@MockBean
 	protected AccessTokenInterceptor accessTokenInterceptor;
 
-	@MockBean
+	@SpyBean
 	protected AuthorizationHeaderInterceptor authorizationHeaderInterceptor;
 
 }

--- a/src/test/java/com/dowe/RestDocsSupport.java
+++ b/src/test/java/com/dowe/RestDocsSupport.java
@@ -9,6 +9,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.dowe.auth.application.AuthService;
 import com.dowe.auth.presentation.AuthController;
 import com.dowe.util.interceptor.AccessTokenInterceptor;
+import com.dowe.util.interceptor.AuthorizationHeaderInterceptor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(controllers = {
@@ -28,5 +29,8 @@ public abstract class RestDocsSupport {
 
 	@MockBean
 	protected AccessTokenInterceptor accessTokenInterceptor;
+
+	@MockBean
+	protected AuthorizationHeaderInterceptor authorizationHeaderInterceptor;
 
 }

--- a/src/test/java/com/dowe/auth/application/TokenManagerTest.java
+++ b/src/test/java/com/dowe/auth/application/TokenManagerTest.java
@@ -1,6 +1,6 @@
 package com.dowe.auth.application;
 
-import static com.dowe.exception.auth.TokenType.*;
+import static com.dowe.auth.TokenType.*;
 import static com.dowe.util.AppConstants.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -48,8 +48,8 @@ class TokenManagerTest extends IntegrationTestSupport {
 		TokenPair tokenPair = tokenManager.issue(memberId);
 
 		// then
-		Long memberIdInAccessToken = tokenManager.parse(tokenPair.getAccessToken(), ACCESS_TOKEN);
-		Long memberIdInRefreshToken = tokenManager.parse(tokenPair.getRefreshToken(), REFRESH_TOKEN);
+		Long memberIdInAccessToken = tokenManager.parse(tokenPair.getAccessToken(), ACCESS);
+		Long memberIdInRefreshToken = tokenManager.parse(tokenPair.getRefreshToken(), REFRESH);
 
 		assertThat(memberId).isEqualTo(memberIdInAccessToken);
 		assertThat(memberId).isEqualTo(memberIdInRefreshToken);
@@ -103,12 +103,12 @@ class TokenManagerTest extends IntegrationTestSupport {
 			.setIssuedAt(now)
 			.setExpiration(now)
 			.claim(MEMBER_ID, 1L)
-			.claim(TOKEN_TYPE, ACCESS_TOKEN)
+			.claim(TOKEN_TYPE, ACCESS)
 			.signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
 			.compact();
 
 		// when // then
-		assertThatThrownBy(() -> tokenManager.parse(expiredToken, ACCESS_TOKEN))
+		assertThatThrownBy(() -> tokenManager.parse(expiredToken, ACCESS))
 			.isInstanceOf(ExpiredTokenException.class);
 	}
 

--- a/src/test/java/com/dowe/auth/application/TokenManagerTest.java
+++ b/src/test/java/com/dowe/auth/application/TokenManagerTest.java
@@ -1,5 +1,6 @@
 package com.dowe.auth.application;
 
+import static com.dowe.exception.auth.TokenType.*;
 import static com.dowe.util.AppConstants.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -47,8 +48,8 @@ class TokenManagerTest extends IntegrationTestSupport {
 		TokenPair tokenPair = tokenManager.issue(memberId);
 
 		// then
-		Long memberIdInAccessToken = tokenManager.parse(tokenPair.getAccessToken());
-		Long memberIdInRefreshToken = tokenManager.parse(tokenPair.getRefreshToken());
+		Long memberIdInAccessToken = tokenManager.parse(tokenPair.getAccessToken(), ACCESS_TOKEN);
+		Long memberIdInRefreshToken = tokenManager.parse(tokenPair.getRefreshToken(), REFRESH_TOKEN);
 
 		assertThat(memberId).isEqualTo(memberIdInAccessToken);
 		assertThat(memberId).isEqualTo(memberIdInRefreshToken);
@@ -102,11 +103,12 @@ class TokenManagerTest extends IntegrationTestSupport {
 			.setIssuedAt(now)
 			.setExpiration(now)
 			.claim(MEMBER_ID, 1L)
+			.claim(TOKEN_TYPE, ACCESS_TOKEN)
 			.signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
 			.compact();
 
 		// when // then
-		assertThatThrownBy(() -> tokenManager.parse(expiredToken))
+		assertThatThrownBy(() -> tokenManager.parse(expiredToken, ACCESS_TOKEN))
 			.isInstanceOf(ExpiredTokenException.class);
 	}
 

--- a/src/test/java/com/dowe/auth/application/TokenManagerTest.java
+++ b/src/test/java/com/dowe/auth/application/TokenManagerTest.java
@@ -114,8 +114,33 @@ class TokenManagerTest extends IntegrationTestSupport {
 	}
 
 	@Test
+	@DisplayName("토큰 타입이 일치하면 정상적으로 memberId를 반환한다")
+	void parseMatchedTokenType() {
+		// given
+		Date issuedAt = new Date();
+		Date expiration = new Date(issuedAt.getTime() + 5000);
+		Long memberId = 1L;
+
+		String accessToken = Jwts.builder()
+			.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+			.setIssuer(jwtProperties.getIssuer())
+			.setIssuedAt(issuedAt)
+			.setExpiration(expiration)
+			.claim(MEMBER_ID, memberId)
+			.claim(TOKEN_TYPE, ACCESS)
+			.signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
+			.compact();
+
+		// when
+		Long loginMemberId = tokenManager.parse(accessToken, ACCESS);
+
+		// then
+		assertThat(loginMemberId).isEqualTo(memberId);
+	}
+
+	@Test
 	@DisplayName("토큰 타입이 일치하지 않으면 예외가 발생한다")
-	void parseTokenType() {
+	void parseMismatchedTokenType() {
 		// given
 		Date issuedAt = new Date();
 		Date expiration = new Date(issuedAt.getTime() + 5000);

--- a/src/test/java/com/dowe/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/dowe/auth/presentation/AuthControllerTest.java
@@ -20,6 +20,7 @@ import com.dowe.auth.application.AuthService;
 import com.dowe.auth.dto.LoginData;
 import com.dowe.exception.ErrorType;
 import com.dowe.exception.auth.InvalidAuthorizationCodeException;
+import com.dowe.exception.auth.InvalidAuthorizationHeaderException;
 import com.dowe.exception.auth.InvalidProviderException;
 import com.dowe.member.Provider;
 import com.dowe.util.api.ResponseResult;
@@ -196,6 +197,33 @@ class AuthControllerTest extends RestDocsSupport {
 				pathParameters(
 					parameterWithName("provider").description("OAuth Provider")
 				),
+				responseFields(
+					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
+					fieldWithPath("status").type(JsonFieldType.STRING).description("상태"),
+					fieldWithPath("result").type(JsonFieldType.STRING).description("결과"),
+					fieldWithPath("data").type(JsonFieldType.ARRAY).description("응답 데이터"),
+					fieldWithPath("data[].type").type(JsonFieldType.STRING).description("오류 타입"),
+					fieldWithPath("data[].message").type(JsonFieldType.STRING).description("오류 메시지")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("토큰 리프레싱 실패 : 유효하지 않은 인증 헤더")
+	void refreshFail_invalidAuthorizationHeader() throws Exception {
+		// when / then
+		mockMvc.perform(get("/oauth/refresh"))
+			.andDo(print())
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.code").value(HttpStatus.UNAUTHORIZED.value()))
+			.andExpect(jsonPath("$.status").value(HttpStatus.UNAUTHORIZED.getReasonPhrase()))
+			.andExpect(jsonPath("$.result").value(ResponseResult.EXCEPTION_OCCURRED.getDescription()))
+			.andExpect(jsonPath("$.data").isArray())
+			.andExpect(jsonPath("$.data[0].type").value(InvalidAuthorizationHeaderException.class.getSimpleName()))
+			.andExpect(jsonPath("$.data[0].message").value(ErrorType.INVALID_AUTHORIZATION_HEADER.getMessage()))
+			.andDo(document("refresh-fail-invalid-authorization-header",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
 				responseFields(
 					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
 					fieldWithPath("status").type(JsonFieldType.STRING).description("상태"),

--- a/src/test/java/com/dowe/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/dowe/auth/presentation/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.dowe.auth.presentation;
 
 import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
@@ -12,16 +13,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.restdocs.payload.JsonFieldType;
 
 import com.dowe.RestDocsSupport;
+import com.dowe.auth.TokenType;
 import com.dowe.auth.application.AuthService;
 import com.dowe.auth.dto.LoginData;
+import com.dowe.auth.dto.TokenPair;
 import com.dowe.exception.ErrorType;
 import com.dowe.exception.auth.InvalidAuthorizationCodeException;
 import com.dowe.exception.auth.InvalidProviderException;
+import com.dowe.exception.auth.InvalidTokenException;
 import com.dowe.member.Provider;
+import com.dowe.util.AppConstants;
 import com.dowe.util.api.ResponseResult;
 
 class AuthControllerTest extends RestDocsSupport {
@@ -142,7 +148,7 @@ class AuthControllerTest extends RestDocsSupport {
 		String authorizationCode = "auth-code";
 
 		// when // then
-		mockMvc.perform(get("/oauth/{provider}", "goooogle")
+		mockMvc.perform(get("/oauth/{provider}", "goooogle")            // TODO: 지금은 실패하는데 피아가 바꾼 경로 적용하면 해결될 듯
 				.param("authorizationCode", authorizationCode))
 			.andDo(print())
 			.andExpect(status().isBadRequest())
@@ -203,6 +209,91 @@ class AuthControllerTest extends RestDocsSupport {
 					fieldWithPath("data").type(JsonFieldType.ARRAY).description("응답 데이터"),
 					fieldWithPath("data[].type").type(JsonFieldType.STRING).description("오류 타입"),
 					fieldWithPath("data[].message").type(JsonFieldType.STRING).description("오류 메시지")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("토큰 refresh 성공")
+	void refreshToken() throws Exception {
+		// given
+		String refreshToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkb3dpdGgiLCJpYXQiOjE3MjA3NTc5NTksImV4cCI6MTcyMTk2NzU1OSwibWVtYmVySWQiOjQsInRva2VuVHlwZSI6IlJFRlJFU0gifQ.O4YHeol1a2yADRCd0zBtpJyThJxeOVjKor_cRLPUTZc";
+		String newRefreshToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkb3dpdGgiLCJpYXQiOjE3MjA3NTc5ODcsImV4cCI6MTcyMTk2NzU4NywibWVtYmVySWQiOjQsInRva2VuVHlwZSI6IlJFRlJFU0gifQ.kIIL6JWkBPARjnheKouAuv0kuOfIIATxEHiuhtsq2w";
+		String accessToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkb3dpdGgiLCJpYXQiOjE3MjA3NTc5ODcsImV4cCI6MTcyMDc1OTc4NywibWVtYmVySWQiOjQsInRva2VuVHlwZSI6IkFDQ0VTUyJ9.7qE6ExR0FAN1aYfekwZ7Lb1eP4BOTv-MNRCFpc9hbhs";
+
+		given(authorizationHeaderInterceptor.preHandle(any(), any(), any()))
+			.willReturn(true);
+
+		given(authService.refresh(eq(refreshToken)))
+			.willReturn(new TokenPair(accessToken, newRefreshToken));
+
+		// when // then
+		mockMvc.perform(get("/oauth/refresh")
+				.header(HttpHeaders.AUTHORIZATION, AppConstants.BEARER + refreshToken))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+			.andExpect(jsonPath("$.status").value(HttpStatus.OK.getReasonPhrase()))
+			.andExpect(jsonPath("$.result").value(ResponseResult.TOKEN_REFRESH_SUCCESS.getDescription()))
+			.andExpect(jsonPath("$.data.accessToken").value(accessToken))
+			.andExpect(jsonPath("$.data.refreshToken").value(newRefreshToken))
+			.andDo(document("token-refresh-success",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				requestHeaders(
+					headerWithName(HttpHeaders.AUTHORIZATION).description("refresh token")
+				),
+				responseFields(
+					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
+					fieldWithPath("status").type(JsonFieldType.STRING).description("상태"),
+					fieldWithPath("result").type(JsonFieldType.STRING).description("결과"),
+					fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+					fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("access token"),
+					fieldWithPath("data.refreshToken").type(JsonFieldType.STRING).description("refresh token")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("토큰 refresh 실패 : refreshToken이 아닌 accessToken을 전달")
+	void refreshTokenFailInvalidTokenType() throws Exception {
+		// given
+		String accessToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkb3dpdGgiLCJpYXQiOjE3MjA3NTc5ODcsImV4cCI6MTcyMDc1OTc4NywibWVtYmVySWQiOjQsInRva2VuVHlwZSI6IkFDQ0VTUyJ9.7qE6ExR0FAN1aYfekwZ7Lb1eP4BOTv-MNRCFpc9hbhs";
+
+		given(authorizationHeaderInterceptor.preHandle(any(), any(), any()))
+			.willReturn(true);
+
+		given(authService.refresh(eq(accessToken)))
+			.willThrow(new InvalidTokenException(TokenType.ACCESS, TokenType.REFRESH));
+
+		// when // then
+		mockMvc.perform(get("/oauth/refresh")
+				.header(HttpHeaders.AUTHORIZATION, AppConstants.BEARER + accessToken))
+			.andDo(print())
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.code").value(HttpStatus.UNAUTHORIZED.value()))
+			.andExpect(jsonPath("$.status").value(HttpStatus.UNAUTHORIZED.getReasonPhrase()))
+			.andExpect(jsonPath("$.result").value(ResponseResult.EXCEPTION_OCCURRED.getDescription()))
+			.andExpect(jsonPath("$.data").isArray())
+			.andExpect(jsonPath("$.data[0].type").value(InvalidTokenException.class.getSimpleName()))
+			.andExpect(jsonPath("$.data[0].message").value(ErrorType.INVALID_TOKEN.getMessage()))
+			.andExpect(jsonPath("$.data[0].currentTokenType").value(TokenType.ACCESS.getDescription()))
+			.andExpect(jsonPath("$.data[0].needTokenType").value(TokenType.REFRESH.getDescription()))
+			.andDo(document("token-refresh-fail-hand-over-access-token",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				requestHeaders(
+					headerWithName(HttpHeaders.AUTHORIZATION).description("access token")
+				),
+				responseFields(
+					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
+					fieldWithPath("status").type(JsonFieldType.STRING).description("상태"),
+					fieldWithPath("result").type(JsonFieldType.STRING).description("결과"),
+					fieldWithPath("data").type(JsonFieldType.ARRAY).description("응답 데이터"),
+					fieldWithPath("data[].type").type(JsonFieldType.STRING).description("오류 타입"),
+					fieldWithPath("data[].message").type(JsonFieldType.STRING).description("오류 메시지"),
+					fieldWithPath("data[].currentTokenType").type(JsonFieldType.STRING).description("클라이언트가 보낸 토큰 타입"),
+					fieldWithPath("data[].needTokenType").type(JsonFieldType.STRING).description("실제 필요한 토큰 타입")
 				)
 			));
 	}

--- a/src/test/java/com/dowe/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/dowe/auth/presentation/AuthControllerTest.java
@@ -212,7 +212,7 @@ class AuthControllerTest extends RestDocsSupport {
 	@DisplayName("토큰 리프레싱 실패 : 유효하지 않은 인증 헤더")
 	void refreshFail_invalidAuthorizationHeader() throws Exception {
 		// when / then
-		mockMvc.perform(get("/oauth/refresh"))
+		mockMvc.perform(get("/refresh"))
 			.andDo(print())
 			.andExpect(status().isUnauthorized())
 			.andExpect(jsonPath("$.code").value(HttpStatus.UNAUTHORIZED.value()))

--- a/src/test/java/com/dowe/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/dowe/auth/presentation/AuthControllerTest.java
@@ -57,12 +57,12 @@ class AuthControllerTest extends RestDocsSupport {
 			.willReturn(data);
 
 		// when // then
-		mockMvc.perform(get("/oauth/{provider}", provider.name().toLowerCase())
+		mockMvc.perform(post("/oauth/{provider}", provider.name().toLowerCase())
 				.param("authorizationCode", authorizationCode))
 			.andDo(print())
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
-			.andExpect(jsonPath("$.status").value(HttpStatus.OK.getReasonPhrase()))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.code").value(HttpStatus.CREATED.value()))
+			.andExpect(jsonPath("$.status").value(HttpStatus.CREATED.getReasonPhrase()))
 			.andExpect(jsonPath("$.result").value(ResponseResult.LOGIN_SUCCESS.getDescription()))
 			.andExpect(jsonPath("$.data.code").value(data.getCode()))
 			.andExpect(jsonPath("$.data.name").value(data.getName()))
@@ -110,12 +110,12 @@ class AuthControllerTest extends RestDocsSupport {
 			.willReturn(data);
 
 		// when // then
-		mockMvc.perform(get("/oauth/{provider}", provider.name().toLowerCase())
+		mockMvc.perform(post("/oauth/{provider}", provider.name().toLowerCase())
 				.param("authorizationCode", authorizationCode))
 			.andDo(print())
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
-			.andExpect(jsonPath("$.status").value(HttpStatus.OK.getReasonPhrase()))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.code").value(HttpStatus.CREATED.value()))
+			.andExpect(jsonPath("$.status").value(HttpStatus.CREATED.getReasonPhrase()))
 			.andExpect(jsonPath("$.result").value(ResponseResult.LOGIN_SUCCESS.getDescription()))
 			.andExpect(jsonPath("$.data.code").value(data.getCode()))
 			.andExpect(jsonPath("$.data.name").value(data.getName()))
@@ -149,7 +149,7 @@ class AuthControllerTest extends RestDocsSupport {
 		String authorizationCode = "auth-code";
 
 		// when // then
-		mockMvc.perform(get("/oauth/{provider}", "goooogle")
+		mockMvc.perform(post("/oauth/{provider}", "goooogle")
 				.param("authorizationCode", authorizationCode))
 			.andDo(print())
 			.andExpect(status().isBadRequest())
@@ -187,7 +187,7 @@ class AuthControllerTest extends RestDocsSupport {
 			.willThrow(new InvalidAuthorizationCodeException());
 
 		// when // then
-		mockMvc.perform(get("/oauth/{provider}", provider.name().toLowerCase())
+		mockMvc.perform(post("/oauth/{provider}", provider.name().toLowerCase())
 				.param("authorizationCode", authorizationCode))
 			.andDo(print())
 			.andExpect(status().isBadRequest())
@@ -218,7 +218,7 @@ class AuthControllerTest extends RestDocsSupport {
 	@DisplayName("토큰 리프레싱 실패 : 유효하지 않은 인증 헤더")
 	void refreshFail_invalidAuthorizationHeader() throws Exception {
 		// when / then
-		mockMvc.perform(get("/refresh"))
+		mockMvc.perform(patch("/refresh"))
 			.andDo(print())
 			.andExpect(status().isUnauthorized())
 			.andExpect(jsonPath("$.code").value(HttpStatus.UNAUTHORIZED.value()))
@@ -249,14 +249,14 @@ class AuthControllerTest extends RestDocsSupport {
 		String newRefreshToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkb3dpdGgiLCJpYXQiOjE3MjA3NTc5ODcsImV4cCI6MTcyMTk2NzU4NywibWVtYmVySWQiOjQsInRva2VuVHlwZSI6IlJFRlJFU0gifQ.kIIL6JWkBPARjnheKouAuv0kuOfIIATxEHiuhtsq2w";
 		String accessToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkb3dpdGgiLCJpYXQiOjE3MjA3NTc5ODcsImV4cCI6MTcyMDc1OTc4NywibWVtYmVySWQiOjQsInRva2VuVHlwZSI6IkFDQ0VTUyJ9.7qE6ExR0FAN1aYfekwZ7Lb1eP4BOTv-MNRCFpc9hbhs";
 
-		given(authorizationHeaderInterceptor.preHandle(any(), any(), any()))
-			.willReturn(true);
+		doReturn(true).when(authorizationHeaderInterceptor)
+			.preHandle(any(), any(), any());
 
 		given(authService.refresh(eq(refreshToken)))
 			.willReturn(new TokenPair(accessToken, newRefreshToken));
 
 		// when // then
-		mockMvc.perform(get("/refresh")
+		mockMvc.perform(patch("/refresh")
 				.header(HttpHeaders.AUTHORIZATION, AppConstants.BEARER + refreshToken))
 			.andDo(print())
 			.andExpect(status().isOk())
@@ -288,14 +288,14 @@ class AuthControllerTest extends RestDocsSupport {
 		// given
 		String accessToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkb3dpdGgiLCJpYXQiOjE3MjA3NTc5ODcsImV4cCI6MTcyMDc1OTc4NywibWVtYmVySWQiOjQsInRva2VuVHlwZSI6IkFDQ0VTUyJ9.7qE6ExR0FAN1aYfekwZ7Lb1eP4BOTv-MNRCFpc9hbhs";
 
-		given(authorizationHeaderInterceptor.preHandle(any(), any(), any()))
-			.willReturn(true);
+		doReturn(true).when(authorizationHeaderInterceptor)
+			.preHandle(any(), any(), any());
 
 		given(authService.refresh(eq(accessToken)))
 			.willThrow(new InvalidTokenException(TokenType.ACCESS, TokenType.REFRESH));
 
 		// when // then
-		mockMvc.perform(get("/refresh")
+		mockMvc.perform(patch("/refresh")
 				.header(HttpHeaders.AUTHORIZATION, AppConstants.BEARER + accessToken))
 			.andDo(print())
 			.andExpect(status().isUnauthorized())

--- a/src/test/java/com/dowe/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/dowe/exception/GlobalExceptionHandlerTest.java
@@ -79,9 +79,9 @@ class GlobalExceptionHandlerTest {
 		for (int i = 0; i < threadCount; i++) {
 			executorService.submit(() -> {
 				try {
-					ResultActions resultActions = mockMvc.perform(get("/oauth/google")
+					ResultActions resultActions = mockMvc.perform(post("/oauth/google")
 							.param("authorizationCode", authorizationCode))
-						.andExpect(status().isOk());
+						.andExpect(status().isCreated());
 
 					String response = resultActions.andReturn().getResponse().getContentAsString(Charsets.UTF_8);
 					JsonNode rootNode = objectMapper.readTree(response);


### PR DESCRIPTION
- 컨트롤러 테스트
  - 정상 응답
  - 클라이언트쪽에서 access token을 건네준 실패 응답
- TokenManager.refresh 메서드 로직 테스트
  - refresh 로직 내에서 사용한 public 메서드 parse, issue를 AuthService.refresh 메서드 쪽으로 분리 - 테스트 시 parse 로직을 mocking해야 하는데 이 부분이 어색하고, public 메서드가 public 메서드를 사용하는 것 또한 변경에 취약하다고 생각하여 이와 같이 구조 변경
  - 정상적으로 토큰을 refresh 후, 토큰 쌍 반환하는 테스트
  - 올바르지 않은 토큰을 받아 예외를 던지는 테스트
  - memberToken의 업데이트 시 dirty checking을 사용하기 위해 TokenManager에 @Transactional 애노테이션 부착
- /oauth/refresh URL을 일단 그대로 사용하였음